### PR TITLE
Invalid Danger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ install:
   - bundle install --path=vendor/bundle
   - bundle exec fastlane mac build
 
-before_script:
-  - bundle exec fastlane mac check_pull_request
+# before_script:
+#   - bundle exec fastlane mac check_pull_request
 
 script:
   - bundle exec fastlane mac test


### PR DESCRIPTION
Environment Variables cannot be reachable in TravisCI from forked repo. So set danger to invalid once.

https://docs.travis-ci.com/user/environment-variables/