### PR TITLE
Add Mint package manager support 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
     name: "AppIcon",
+    products: [
+        .executable(name: "AppIcon", targets: ["AppIcon"])
+    ],
     dependencies: [
         .package(url: "https://github.com/kylef/Commander", from: "0.8.0"),
         .package(url: "https://github.com/kareman/SwiftShell.git", "4.0.0"..<"5.0.0"),

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ AppIcon.appiconset
 $ brew install Nonchalant/appicon/appicon
 ```
 
+### [Mint](https://github.com/yonaskolb/Mint)
+
+```bash
+$ mint run nonchalant/appicon
+```
+
 ### Manual
 
 Clone the master branch of the repository, then run make install.


### PR DESCRIPTION
You can check out the correctness of implementation by running it from my fork like that 

```bash
$ mint run alphatroya/appicon@mint
```