### PR TITLE
Disable sandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ debug:
 	swift build
 
 build:
-	swift build -c release -Xswiftc -static-stdlib
+	swift build -c release -Xswiftc -static-stdlib --disable-sandbox
 
 test:
 	swift test


### PR DESCRIPTION
`--disable-sandbox` should be passed to build on Homebrew sandbox.

```console
$ xcodebuild -version
Xcode 10.0
Build version 10A254a
$ make install PREFIX=`brew --prefix`
```

```console
$ brew tap Nonchalant/appicon
$ brew install -s Nonchalant/appicon/appicon
```