### PR TITLE
Update SwiftShell library dependency to 5.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/kareman/SwiftShell.git",
         "state": {
           "branch": null,
-          "revision": "beebe43c986d89ea5359ac3adcb42dac94e5e08a",
-          "version": "4.1.2"
+          "revision": "99680b2efc7c7dbcace1da0b3979d266f02e213c",
+          "version": "5.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/kylef/Commander", from: "0.8.0"),
-        .package(url: "https://github.com/kareman/SwiftShell.git", "4.0.0"..<"5.0.0"),
+        .package(url: "https://github.com/kareman/SwiftShell.git", from: "5.1.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
This fix resolve the building issue on Swift 5.3.

More info: https://github.com/kareman/SwiftShell/issues/91