### PR TITLE
Replace Commander library by ArgumentParser

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "Commander",
-        "repositoryURL": "https://github.com/kylef/Commander",
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "e5b50ad7b2e91eeb828393e89b03577b16be7db9",
-          "version": "0.8.0"
-        }
-      },
-      {
-        "package": "Spectre",
-        "repositoryURL": "https://github.com/kylef/Spectre.git",
-        "state": {
-          "branch": null,
-          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
-          "version": "0.9.0"
+          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
+          "version": "0.3.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.1
 
 import PackageDescription
 
@@ -8,7 +8,7 @@ let package = Package(
         .executable(name: "AppIcon", targets: ["AppIcon"])
     ],
     dependencies: [
-        .package(url: "https://github.com/kylef/Commander", from: "0.8.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.1"),
         .package(url: "https://github.com/kareman/SwiftShell.git", from: "5.1.0"),
     ],
     targets: [
@@ -21,7 +21,7 @@ let package = Package(
         .target(
             name: "AppIconCore",
             dependencies: [
-                "Commander",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 "SwiftShell",
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,5 @@
 // swift-tools-version:5.3
 
-
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
I have courage to suggest you to replace Commander library by [apple argument parser](https://github.com/apple/swift-argument-parser) library. This library from maintainers of the Swift have better support and stability. 

Also it uses new Swift 5.1 features (property wrappers) and code looks very nice (IMHO of course).

Another benefit - build in generation of the [shell completions](https://github.com/apple/swift-argument-parser/blob/main/Documentation/07%20Completion%20Scripts.md).

In this PR I tried to keep the same options and flags names to provide compatibility with your documentation.

New interface: 
<img width="1049" alt="Снимок экрана 2020-10-02 в 11 03 56" src="https://user-images.githubusercontent.com/4927633/94901259-0a0f0600-049f-11eb-9d9e-5142889e8650.png">

The old one:
<img width="730" alt="Снимок экрана 2020-10-02 в 11 04 05" src="https://user-images.githubusercontent.com/4927633/94901268-0ed3ba00-049f-11eb-8cb2-97bf1f996d39.png">

