### PR TITLE
Validation of png extension to be case insensitive

### DIFF
--- a/Sources/AppIcon/main.swift
+++ b/Sources/AppIcon/main.swift
@@ -28,7 +28,8 @@ struct AppIcon: ParsableCommand {
     var watch = false
 
     func run() throws {
-        guard image.hasSuffix(".png") else {
+        guard let `extension` = image.split(separator: ".").last,
+              `extension`.caseInsensitiveCompare("png") == .orderedSame else {
             throw ValidationError("image path should have .png extension")
         }
 


### PR DESCRIPTION
Fix validation of png extension to be case insensitive.
I don't think it's necessary to validate case sensitive in extension.